### PR TITLE
Add configuration to completely disable the auth options

### DIFF
--- a/ClntCfgMgr/ClntCfgMgr.cpp
+++ b/ClntCfgMgr/ClntCfgMgr.cpp
@@ -520,6 +520,7 @@ bool TClntCfgMgr::validateConfig()
 
     // Validate authentication settings
     switch (getAuthProtocol()) {
+    case AUTH_PROTO_NOT_SUPPORTED:
     case AUTH_PROTO_NONE:
         break;
     case AUTH_PROTO_DELAYED: {

--- a/ClntCfgMgr/ClntParser.cpp
+++ b/ClntCfgMgr/ClntParser.cpp
@@ -2086,7 +2086,10 @@ case 122:
 case 123:
 #line 572 "ClntParser.y"
 {
-    if (!strcasecmp(yyvsp[0].strval,"none")) {
+    if (!strcasecmp(yyvsp[0].strval, "not-supported")) {
+        CfgMgr->setAuthProtocol(AUTH_PROTO_NOT_SUPPORTED);
+        CfgMgr->setAuthAlgorithm(AUTH_ALGORITHM_NONE);
+    } else if (!strcasecmp(yyvsp[0].strval,"none")) {
         CfgMgr->setAuthProtocol(AUTH_PROTO_NONE);
         CfgMgr->setAuthAlgorithm(AUTH_ALGORITHM_NONE);
     } else if (!strcasecmp(yyvsp[0].strval, "delayed")) {

--- a/ClntCfgMgr/ClntParser.y
+++ b/ClntCfgMgr/ClntParser.y
@@ -570,7 +570,10 @@ AuthAcceptMethods
 
 AuthProtocol
 : AUTH_PROTOCOL_ STRING_ {
-    if (!strcasecmp($2,"none")) {
+    if (!strcasecmp($2, "not-supported")) {
+        CfgMgr->setAuthProtocol(AUTH_PROTO_NOT_SUPPORTED);
+        CfgMgr->setAuthAlgorithm(AUTH_ALGORITHM_NONE);
+    } else if (!strcasecmp($2,"none")) {
         CfgMgr->setAuthProtocol(AUTH_PROTO_NONE);
         CfgMgr->setAuthAlgorithm(AUTH_ALGORITHM_NONE);
     } else if (!strcasecmp($2, "delayed")) {

--- a/ClntMessages/ClntMsg.cpp
+++ b/ClntMessages/ClntMsg.cpp
@@ -445,6 +445,9 @@ void TClntMsg::appendAuthenticationOption()
     string realm;
 
     switch (ClntCfgMgr().getAuthProtocol()) {
+    case AUTH_PROTO_NOT_SUPPORTED: {
+        return;
+    }
     case AUTH_PROTO_NONE: {
         algorithm = 0;
         break;
@@ -1105,6 +1108,7 @@ bool TClntMsg::checkReceivedAuthOption() {
     }
 
     switch (ClntCfgMgr().getAuthProtocol()) {
+    case AUTH_PROTO_NOT_SUPPORTED:
     case AUTH_PROTO_NONE: {
         return true;
     }

--- a/Messages/Msg.cpp
+++ b/Messages/Msg.cpp
@@ -156,6 +156,7 @@ void TMsg::calculateDigests(char* buffer, size_t len) {
         }
         return;
     }
+    case AUTH_PROTO_NOT_SUPPORTED:
     case AUTH_PROTO_NONE: {
         // don't calculate anything
         return;
@@ -293,6 +294,7 @@ bool TMsg::validateAuthInfo(char *buf, int bufSize,
     bool dt_in_list = false;
 
     switch (proto) {
+    case AUTH_PROTO_NOT_SUPPORTED:
     case AUTH_PROTO_NONE:
         return true;
     case AUTH_PROTO_DELAYED: {

--- a/Misc/DHCPConst.h
+++ b/Misc/DHCPConst.h
@@ -247,6 +247,7 @@ int allowOptInMsg(int msgType, int optType);
 
 // Supported authorization protocols
 enum AuthProtocols {
+    AUTH_PROTO_NOT_SUPPORTED = -1, // Don't even mention auth
     AUTH_PROTO_NONE = 0,    // disabled
     AUTH_PROTO_DELAYED = 2, // RFC 3315
     AUTH_PROTO_RECONFIGURE_KEY = 3, // RFC 3315, section 21.5.1


### PR DESCRIPTION
Solves the problem I was having with my ISP ignoring my solicit requests by adding a configuration option to completely disable the auth component of the request.

edit: see http://klub.com.pl/lists/dibbler/2013-October/000554.html
