### PR TITLE
Fixed trying to write reconfigure-key xml when there's not reconfigure key

### DIFF
--- a/AddrMgr/AddrClient.cpp
+++ b/AddrMgr/AddrClient.cpp
@@ -355,9 +355,10 @@ std::ostream & operator<<(std::ostream & strum, TAddrClient &x)
         strum << "  <!-- 1-byte length DUID. DECLINED-ADDRESSES -->" << endl;
 
     // reconfigure-key
-    strum << "    <ReconfigureKey length=\"" << x.ReconfKey_.size() << "\">"
-          << hexToText(&x.ReconfKey_[0], x.ReconfKey_.size(), false)
-          << "</ReconfigureKey>" << endl;
+	if( x.ReconfKey_.size() )
+		strum << "    <ReconfigureKey length=\"" << x.ReconfKey_.size() << "\">"
+			  << hexToText(&x.ReconfKey_[0], x.ReconfKey_.size(), false)
+			  << "</ReconfigureKey>" << endl;
 
     strum << "    <!-- " << x.IAsLst.count() << " IA(s) -->" << endl;
     SPtr<TAddrIA> ptr;


### PR DESCRIPTION
Tomasz, I need help understanding this issue. I don't know if just the if below is the right thing to do or actually we should be hunting down why x.ReconfKey_ is empty.

Right now dibbler-client is going kaput (runtime error) when running
