### PR TITLE
Fix RENEW in Windows

### DIFF
--- a/Port-win32/lowlevel-win32.c
+++ b/Port-win32/lowlevel-win32.c
@@ -339,6 +339,7 @@ extern int ipaddr_add(const char * ifacename, int ifaceid, const char * addr,
     sprintf(arg8,"preferredlifetime=%u", pref);
     // use _P_DETACH to speed things up, (but the tentative detection will surely fail)
     i=_spawnl(_P_WAIT, netshPath, netshPath, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, NULL);
+    if (i) { i = _spawnl(_P_WAIT, netshPath, netshPath, arg1, arg2, "set", arg4, arg5, arg6, arg7, arg8, NULL); }
     return i;
 }
 
@@ -622,13 +623,8 @@ int prefix_add(const char* ifname, int ifindex, const char* prefixPlain, int pre
 
     sprintf(buf, "%s %s %s %s %s %s %s %s %s %s", arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
     i=_spawnl(_P_WAIT,netshPath,netshPath,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10, NULL);
-
-    if (i==-1) {
-        /// @todo: some better error support
-        return -1;
-    }
-
-    return LOWLEVEL_NO_ERROR;
+    if (i) { i = _spawnl(_P_WAIT, netshPath, netshPath, arg1, arg2, "set", arg4, arg5, arg6, arg7, arg8, arg9, arg10, NULL); }
+    return i;
 }
 
 int prefix_update(const char* ifname, int ifindex, const char* prefixPlain, int prefixLength,


### PR DESCRIPTION
This one corrects a bug in the Win32 port of the client:

After DHCP renewal, saving the renewed address or prefix fails. Windows will mark the address as "deprecated" after the original preferred lifetime has expired, effectively breaking IPv6 connectivity.

Reason: "netsh int ipv6 add address" will error out with "Object already exists" when using it on an existing address. Existing addresses can only be updated with "netsh int ipv6 set address".

This PR retries saving the address using "netsh int ipv6 set" in case "netsh int ipv6 add" fails. This is the safest approach, imo, because it will take care of re-adding OR renewing the address in both, ipaddr_add() and ipaddr_update().

Tested on Windows 2012R2 only, as that's the only box I have which is currently connected to an IPv6 network. Should work on anything XP or newer, though.
