### PR TITLE
Cloud dibbler

### DIFF
--- a/ClntIfaceMgr/ClntIfaceIface.cpp
+++ b/ClntIfaceMgr/ClntIfaceIface.cpp
@@ -38,16 +38,16 @@ TClntIfaceIface::TClntIfaceIface(char * name, int id, unsigned int flags, char* 
 
     DnsConfigured = ! FLUSH_OTHER_CONFIGURED_DNS_SERVERS;
 
-    unlink(WORKDIR"/"OPTION_DNS_SERVERS_FILENAME);
-    unlink(WORKDIR"/"OPTION_DOMAINS_FILENAME);
-    unlink(WORKDIR"/"OPTION_NTP_SERVERS_FILENAME);
-    unlink(WORKDIR"/"OPTION_TIMEZONE_FILENAME);
-    unlink(WORKDIR"/"OPTION_SIP_SERVERS_FILENAME);
-    unlink(WORKDIR"/"OPTION_SIP_DOMAINS_FILENAME);
-    unlink(WORKDIR"/"OPTION_NIS_SERVERS_FILENAME);
-    unlink(WORKDIR"/"OPTION_NIS_DOMAIN_FILENAME);
-    unlink(WORKDIR"/"OPTION_NISP_SERVERS_FILENAME);
-    unlink(WORKDIR"/"OPTION_NISP_DOMAIN_FILENAME);
+    unlink(OPTION_DNS_SERVERS_FILENAME);
+    unlink(OPTION_DOMAINS_FILENAME);
+    unlink(OPTION_NTP_SERVERS_FILENAME);
+    unlink(OPTION_TIMEZONE_FILENAME);
+    unlink(OPTION_SIP_SERVERS_FILENAME);
+    unlink(OPTION_SIP_DOMAINS_FILENAME);
+    unlink(OPTION_NIS_SERVERS_FILENAME);
+    unlink(OPTION_NIS_DOMAIN_FILENAME);
+    unlink(OPTION_NISP_SERVERS_FILENAME);
+    unlink(OPTION_NISP_DOMAIN_FILENAME);
 
     setPrefixLength(CLIENT_DEFAULT_PREFIX_LENGTH);
 }
@@ -96,7 +96,7 @@ bool TClntIfaceIface::setDNSServerLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv,
             Log(Notice) << "Removing DNS server " << *old << " on interface "
                         << this->getName() << "/" << this->getID() << " (no longer valid)." << LogEnd;
             dns_del(this->getName(), this->getID(), old->getPlain());
-            this->delString(WORKDIR"/"OPTION_DNS_SERVERS_FILENAME,old->getPlain());
+            this->delString(OPTION_DNS_SERVERS_FILENAME,old->getPlain());
             this->DNSServerLst.del();
         }
     }
@@ -121,7 +121,7 @@ bool TClntIfaceIface::setDNSServerLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv,
             Log(Notice) << "Setting up DNS server " << * addr << " on interface "
                         << this->getName() << "/" << this->getID() << "." << LogEnd;
             dns_add(this->getName(), this->getID(), addr->getPlain());
-            this->addString(WORKDIR"/"OPTION_DNS_SERVERS_FILENAME,addr->getPlain());
+            this->addString(OPTION_DNS_SERVERS_FILENAME,addr->getPlain());
             this->DNSServerLst.append(addr);
         }
     }
@@ -148,7 +148,7 @@ bool TClntIfaceIface::setDomainLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv, List(s
             Log(Notice) << "Removing domain " << *old << " from interface "
                         << this->getName() << "/" << this->getID() << " (no longer valid)." << LogEnd;
             domain_del(this->getName(), this->getID(), old->c_str());
-            this->delString(WORKDIR"/"OPTION_DOMAINS_FILENAME,old->c_str());
+            this->delString(OPTION_DOMAINS_FILENAME,old->c_str());
             this->DomainLst.del();
         }
     }
@@ -173,7 +173,7 @@ bool TClntIfaceIface::setDomainLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv, List(s
             Log(Notice) << "Setting up Domain " << * domain << " on interface "
                         << this->getName() << "/" << this->getID() << "." << LogEnd;
             domain_add(this->getName(), this->getID(), domain->c_str());
-            this->addString(WORKDIR"/"OPTION_DOMAINS_FILENAME,domain->c_str());
+            this->addString(OPTION_DOMAINS_FILENAME,domain->c_str());
             this->DomainLst.append(domain);
         }
     }
@@ -201,7 +201,7 @@ bool TClntIfaceIface::setNTPServerLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv,
             Log(Notice) << "Removing NTP server " << *old << " on interface "
                         << this->getName() << "/" << this->getID() << " (no longer valid)." << LogEnd;
             ntp_del(this->getName(), this->getID(), old->getPlain());
-            this->delString(WORKDIR"/"OPTION_NTP_SERVERS_FILENAME,old->getPlain());
+            this->delString(OPTION_NTP_SERVERS_FILENAME,old->getPlain());
             this->NTPServerLst.del();
         }
     }
@@ -226,7 +226,7 @@ bool TClntIfaceIface::setNTPServerLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv,
             Log(Notice) << "Setting up NTP server " << * addr << " on the interface "
                         << this->getName() << "/" << this->getID() << "." << LogEnd;
             ntp_add(this->getName(), this->getID(), addr->getPlain());
-            this->addString(WORKDIR"/"OPTION_NTP_SERVERS_FILENAME,addr->getPlain());
+            this->addString(OPTION_NTP_SERVERS_FILENAME,addr->getPlain());
             this->NTPServerLst.append(addr);
         }
     }
@@ -245,7 +245,7 @@ bool TClntIfaceIface::setTimezone(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv, const s
     Log(Notice) << "Setting up timezone " << timezone << " (obtained on the interface "
                 << this->getName() << "/" << this->getID() << ")." << LogEnd;
     timezone_set(this->getName(), this->getID(), timezone.c_str());
-    this->setString(WORKDIR"/"OPTION_TIMEZONE_FILENAME,timezone.c_str());
+    this->setString(OPTION_TIMEZONE_FILENAME,timezone.c_str());
     return true;
 }
 
@@ -270,7 +270,7 @@ bool TClntIfaceIface::setSIPServerLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv,
             Log(Notice) << "Removing SIP server " << *old << " on interface "
                         << this->getName() << "/" << this->getID() << " (no longer valid)." << LogEnd;
             sipserver_del(this->getName(), this->getID(), old->getPlain());
-            this->delString(WORKDIR"/"OPTION_SIP_SERVERS_FILENAME,old->getPlain());
+            this->delString(OPTION_SIP_SERVERS_FILENAME,old->getPlain());
             this->SIPServerLst.del();
         }
     }
@@ -295,7 +295,7 @@ bool TClntIfaceIface::setSIPServerLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv,
             Log(Notice) << "Setting up SIP server " << * addr << " on interface "
                         << this->getName() << "/" << this->getID() << "." << LogEnd;
             sipserver_add(this->getName(), this->getID(), addr->getPlain());
-            this->addString(WORKDIR"/"OPTION_SIP_SERVERS_FILENAME,addr->getPlain());
+            this->addString(OPTION_SIP_SERVERS_FILENAME,addr->getPlain());
             this->SIPServerLst.append(addr);
         }
     }
@@ -321,7 +321,7 @@ bool TClntIfaceIface::setSIPDomainLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv, Lis
             Log(Notice) << "Removing SIP domain " << *old << " from interface "
                         << this->getName() << "/" << this->getID() << " (no longer valid)." << LogEnd;
             sipdomain_del(this->getName(), this->getID(), old->c_str());
-            this->delString(WORKDIR"/"OPTION_SIP_DOMAINS_FILENAME,old->c_str());
+            this->delString(OPTION_SIP_DOMAINS_FILENAME,old->c_str());
             this->SIPDomainLst.del();
         }
     }
@@ -346,7 +346,7 @@ bool TClntIfaceIface::setSIPDomainLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv, Lis
             Log(Notice) << "Setting up SIP domain " << * domain << " on interface "
                         << this->getName() << "/" << this->getID() << "." << LogEnd;
             sipdomain_add(this->getName(), this->getID(), domain->c_str());
-            this->addString( WORKDIR"/"OPTION_SIP_DOMAINS_FILENAME, domain->c_str() );
+            this->addString( OPTION_SIP_DOMAINS_FILENAME, domain->c_str() );
             this->SIPDomainLst.append(domain);
         }
     }
@@ -378,7 +378,7 @@ bool TClntIfaceIface::setNISServerLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv, Lis
             Log(Notice) << "Removing NIS server " << *old << " on interface "
                         << this->getName() << "/" << this->getID() << " (no longer valid)." << LogEnd;
             nisserver_del(this->getName(), this->getID(), old->getPlain());
-            this->delString(WORKDIR"/"OPTION_NIS_SERVERS_FILENAME,old->getPlain());
+            this->delString(OPTION_NIS_SERVERS_FILENAME,old->getPlain());
             this->NISServerLst.del();
         }
     }
@@ -403,7 +403,7 @@ bool TClntIfaceIface::setNISServerLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv, Lis
             Log(Notice) << "Setting up NIS server " << * addr << " on interface "
                         << this->getName() << "/" << this->getID() << "." << LogEnd;
             nisserver_add(this->getName(), this->getID(), addr->getPlain());
-            this->addString(WORKDIR"/"OPTION_NIS_SERVERS_FILENAME, addr->getPlain());
+            this->addString(OPTION_NIS_SERVERS_FILENAME, addr->getPlain());
             this->NISServerLst.append(addr);
         }
     }
@@ -421,7 +421,7 @@ bool TClntIfaceIface::setNISDomain(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv, const 
     Log(Notice) << "Setting up NIS domain " << domain << " on the interface "
                 << this->getName() << "/" << this->getID() << "." << LogEnd;
     nisdomain_set(this->getName(), this->getID(), domain.c_str());
-    this->setString( WORKDIR"/"OPTION_NIS_DOMAIN_FILENAME, domain.c_str() );
+    this->setString( OPTION_NIS_DOMAIN_FILENAME, domain.c_str() );
     return true;
 }
 
@@ -445,7 +445,7 @@ bool TClntIfaceIface::setNISPServerLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv, Li
             Log(Notice) << "Removing NIS+ server " << *old << " on interface "
                         << this->getName() << "/" << this->getID() << " (no longer valid)." << LogEnd;
             nisplusserver_del(this->getName(), this->getID(), old->getPlain());
-            this->delString(WORKDIR"/"OPTION_NISP_SERVERS_FILENAME,old->getPlain());
+            this->delString(OPTION_NISP_SERVERS_FILENAME,old->getPlain());
             this->NISPServerLst.del();
         }
     }
@@ -470,7 +470,7 @@ bool TClntIfaceIface::setNISPServerLst(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv, Li
             Log(Notice) << "Setting up NIS+ server " << * addr << " on interface "
                         << this->getName() << "/" << this->getID() << "." << LogEnd;
             nisplusserver_add(this->getName(), this->getID(), addr->getPlain());
-            this->addString(WORKDIR"/"OPTION_NISP_SERVERS_FILENAME,addr->getPlain());
+            this->addString(OPTION_NISP_SERVERS_FILENAME,addr->getPlain());
             this->NISPServerLst.append(addr);
         }
     }
@@ -488,7 +488,7 @@ bool TClntIfaceIface::setNISPDomain(SPtr<TDUID> duid, SPtr<TIPv6Addr> srv, const
     Log(Notice) << "Setting up NIS+ domain " << domain << " on the interface "
                 << this->getName() << "/" << this->getID() << "." << LogEnd;
     nisplusdomain_set(this->getName(), this->getID(), domain.c_str());
-    this->setString(WORKDIR"/"OPTION_NISP_DOMAIN_FILENAME, domain.c_str());
+    this->setString(OPTION_NISP_DOMAIN_FILENAME, domain.c_str());
     return true;
 }
 

--- a/ClntTransMgr/ClntTransMgr.cpp
+++ b/ClntTransMgr/ClntTransMgr.cpp
@@ -36,6 +36,8 @@ using namespace std;
 
 TClntTransMgr * TClntTransMgr::Instance = 0;
 
+extern char CLNT_LLAADDR[];
+
 void TClntTransMgr::instanceCreate(const std::string& config)
 {
     if (Instance) {
@@ -163,7 +165,8 @@ bool TClntTransMgr::openSockets(SPtr<TClntCfgIface> iface) {
         return false;
     }
 
-    SPtr<TIPv6Addr> addr = new TIPv6Addr(llAddr);
+    SPtr<TIPv6Addr> addr;
+    addr = CLNT_LLAADDR[0] != '\0' ? new TIPv6Addr(CLNT_LLAADDR, true) : new TIPv6Addr(llAddr);
 
     // it's very important to open unicast socket first as it will be used for
     // unicast communication

--- a/ClntTransMgr/ClntTransMgr.cpp
+++ b/ClntTransMgr/ClntTransMgr.cpp
@@ -36,7 +36,7 @@ using namespace std;
 
 TClntTransMgr * TClntTransMgr::Instance = 0;
 
-extern char CLNT_LLAADDR[];
+char CLNT_LLAADDR[sizeof("0000:0000:0000:0000:0000:0000:0000.000.000.000.000")] = "\0";
 
 void TClntTransMgr::instanceCreate(const std::string& config)
 {

--- a/Misc/Portable.h
+++ b/Misc/Portable.h
@@ -153,7 +153,7 @@ extern char *CLNTCONF_FILE;
 #define RESOLVCONF_FILE    "/etc/resolv.conf"
 #define NTPCONF_FILE       "/etc/ntp.conf"
 #define RADVD_FILE         "/etc/dibbler/radvd.conf"
-extern char *CLNTPID_FILE;
+#define CLNTPID_FILE       "/var/lib/dibbler/client.pid"
 #define SRVPID_FILE        "/var/lib/dibbler/server.pid"
 #define RELPID_FILE        "/var/lib/dibbler/relay.pid"
 #define CLNTLOG_FILE       "/var/log/dibbler/dibbler-client.log"

--- a/Misc/Portable.h
+++ b/Misc/Portable.h
@@ -156,7 +156,7 @@ extern char *CLNTCONF_FILE;
 extern char *CLNTPID_FILE;
 #define SRVPID_FILE        "/var/lib/dibbler/server.pid"
 #define RELPID_FILE        "/var/lib/dibbler/relay.pid"
-#define CLNTLOG_FILE       "/var/log/dibbler/dibbler-client.log"
+extern char *CLNTLOG_FILE;
 #define SRVLOG_FILE        "/var/log/dibbler/dibbler-server.log"
 #define RELLOG_FILE        "/var/log/dibbler/dibbler-relay.log"
 #define CLNT_AAASPI_FILE   "/var/lib/dibbler/AAA/AAA-SPI"

--- a/Misc/Portable.h
+++ b/Misc/Portable.h
@@ -147,13 +147,13 @@ struct link_state_notify_t
 #if defined(LINUX) || defined(BSD) || defined(SUNOS)
 #define WORKDIR            "/var/lib/dibbler"
 #define DEFAULT_SCRIPT     ""
-#define CLNTCONF_FILE      "/etc/dibbler/client.conf"
+extern char *CLNTCONF_FILE;
 #define SRVCONF_FILE       "/etc/dibbler/server.conf"
 #define RELCONF_FILE       "/etc/dibbler/relay.conf"
 #define RESOLVCONF_FILE    "/etc/resolv.conf"
 #define NTPCONF_FILE       "/etc/ntp.conf"
 #define RADVD_FILE         "/etc/dibbler/radvd.conf"
-#define CLNTPID_FILE       "/var/lib/dibbler/client.pid"
+extern char *CLNTPID_FILE;
 #define SRVPID_FILE        "/var/lib/dibbler/server.pid"
 #define RELPID_FILE        "/var/lib/dibbler/relay.pid"
 #define CLNTLOG_FILE       "/var/log/dibbler/dibbler-client.log"

--- a/Misc/Portable.h
+++ b/Misc/Portable.h
@@ -145,18 +145,27 @@ struct link_state_notify_t
 #endif
 
 #if defined(LINUX) || defined(BSD) || defined(SUNOS)
-#define WORKDIR            "/var/lib/dibbler"
-#define DEFAULT_SCRIPT     ""
+
+#if defined(LINUX)
+extern char *WORKDIR;
 extern char *CLNTCONF_FILE;
+extern char *CLNTPID_FILE;
+extern char *CLNTLOG_FILE;
+#else
+#define WORKDIR            "/var/lib/dibbler"
+#define CLNTCONF_FILE      "/etc/dibbler/client.conf"
+#define CLNTPID_FILE       "/var/lib/dibbler/client.pid"
+#define CLNTLOG_FILE       "/var/log/dibbler/dibbler-client.log"
+#endif
+
+#define DEFAULT_SCRIPT     ""
 #define SRVCONF_FILE       "/etc/dibbler/server.conf"
 #define RELCONF_FILE       "/etc/dibbler/relay.conf"
 #define RESOLVCONF_FILE    "/etc/resolv.conf"
 #define NTPCONF_FILE       "/etc/ntp.conf"
 #define RADVD_FILE         "/etc/dibbler/radvd.conf"
-extern char *CLNTPID_FILE;
 #define SRVPID_FILE        "/var/lib/dibbler/server.pid"
 #define RELPID_FILE        "/var/lib/dibbler/relay.pid"
-extern char *CLNTLOG_FILE;
 #define SRVLOG_FILE        "/var/log/dibbler/dibbler-server.log"
 #define RELLOG_FILE        "/var/log/dibbler/dibbler-relay.log"
 #define CLNT_AAASPI_FILE   "/var/lib/dibbler/AAA/AAA-SPI"

--- a/Misc/Portable.h
+++ b/Misc/Portable.h
@@ -153,7 +153,7 @@ extern char *CLNTCONF_FILE;
 #define RESOLVCONF_FILE    "/etc/resolv.conf"
 #define NTPCONF_FILE       "/etc/ntp.conf"
 #define RADVD_FILE         "/etc/dibbler/radvd.conf"
-#define CLNTPID_FILE       "/var/lib/dibbler/client.pid"
+extern char *CLNTPID_FILE;
 #define SRVPID_FILE        "/var/lib/dibbler/server.pid"
 #define RELPID_FILE        "/var/lib/dibbler/relay.pid"
 #define CLNTLOG_FILE       "/var/log/dibbler/dibbler-client.log"

--- a/Misc/Portable.h.in
+++ b/Misc/Portable.h.in
@@ -147,13 +147,13 @@ struct link_state_notify_t
 #if defined(LINUX) || defined(BSD) || defined(SUNOS)
 #define WORKDIR            "/var/lib/dibbler"
 #define DEFAULT_SCRIPT     ""
-#define CLNTCONF_FILE      "/etc/dibbler/client.conf"
+extern char *CLNTCONF_FILE;
 #define SRVCONF_FILE       "/etc/dibbler/server.conf"
 #define RELCONF_FILE       "/etc/dibbler/relay.conf"
 #define RESOLVCONF_FILE    "/etc/resolv.conf"
 #define NTPCONF_FILE       "/etc/ntp.conf"
 #define RADVD_FILE         "/etc/dibbler/radvd.conf"
-#define CLNTPID_FILE       "/var/lib/dibbler/client.pid"
+extern char *CLNTPID_FILE;
 #define SRVPID_FILE        "/var/lib/dibbler/server.pid"
 #define RELPID_FILE        "/var/lib/dibbler/relay.pid"
 #define CLNTLOG_FILE       "/var/log/dibbler/dibbler-client.log"

--- a/Misc/Portable.h.in
+++ b/Misc/Portable.h.in
@@ -145,18 +145,27 @@ struct link_state_notify_t
 #endif
 
 #if defined(LINUX) || defined(BSD) || defined(SUNOS)
-#define WORKDIR            "/var/lib/dibbler"
-#define DEFAULT_SCRIPT     ""
+
+#if defined(LINUX)
+extern char *WORKDIR;
 extern char *CLNTCONF_FILE;
+extern char *CLNTPID_FILE;
+extern char *CLNTLOG_FILE;
+#else
+#define WORKDIR            "/var/lib/dibbler"
+#define CLNTCONF_FILE      "/etc/dibbler/client.conf"
+#define CLNTPID_FILE       "/var/lib/dibbler/client.pid"
+#define CLNTLOG_FILE       "/var/log/dibbler/dibbler-client.log"
+#endif
+
+#define DEFAULT_SCRIPT     ""
 #define SRVCONF_FILE       "/etc/dibbler/server.conf"
 #define RELCONF_FILE       "/etc/dibbler/relay.conf"
 #define RESOLVCONF_FILE    "/etc/resolv.conf"
 #define NTPCONF_FILE       "/etc/ntp.conf"
 #define RADVD_FILE         "/etc/dibbler/radvd.conf"
-extern char *CLNTPID_FILE;
 #define SRVPID_FILE        "/var/lib/dibbler/server.pid"
 #define RELPID_FILE        "/var/lib/dibbler/relay.pid"
-#define CLNTLOG_FILE       "/var/log/dibbler/dibbler-client.log"
 #define SRVLOG_FILE        "/var/log/dibbler/dibbler-server.log"
 #define RELLOG_FILE        "/var/log/dibbler/dibbler-relay.log"
 #define CLNT_AAASPI_FILE   "/var/lib/dibbler/AAA/AAA-SPI"

--- a/Port-linux/daemon.cpp
+++ b/Port-linux/daemon.cpp
@@ -29,7 +29,7 @@
 extern int status();
 extern int run();
 
-char *CLNTPID_FILE;
+char *CLNTPID_FILE = (char *) "/var/lib/dibbler/client.pid";
 
 using namespace std;
 

--- a/Port-linux/daemon.cpp
+++ b/Port-linux/daemon.cpp
@@ -29,7 +29,7 @@
 extern int status();
 extern int run();
 
-char *CLNTPID_FILE = CLNTPID_FILE;
+char *CLNTPID_FILE;
 
 using namespace std;
 

--- a/Port-linux/daemon.cpp
+++ b/Port-linux/daemon.cpp
@@ -29,6 +29,8 @@
 extern int status();
 extern int run();
 
+char *CLNTPID_FILE = CLNTPID_FILE;
+
 using namespace std;
 
 /** 

--- a/Port-linux/dibbler-client.cpp
+++ b/Port-linux/dibbler-client.cpp
@@ -164,12 +164,20 @@ int main(int argc, char* argv[])
                 cout << "You've passed me an argument!" << endl;
                 parse_options(argv[i+1],argv[i+2]);
             }
+            if (i + 4 < argc) {
+                cout << "You've passed me another argument!" << endl;
+                parse_options(argv[i+3],argv[i+4]);
+            }
 	        result = start(CLNTPID_FILE, WORKDIR);
         } else if (arg == "run") {
             cout << "I'm running!" << endl;
             if (i + 2 < argc) {
                 cout << "You've passed me an argument!" << endl;
                 parse_options(argv[i+1],argv[i+2]);
+            }
+            if (i + 4 < argc) {
+                cout << "You've passed me another argument!" << endl;
+                parse_options(argv[i+3],argv[i+4]);
             }
             result = run();
         } else if (arg == "stop") {

--- a/Port-linux/dibbler-client.cpp
+++ b/Port-linux/dibbler-client.cpp
@@ -29,6 +29,7 @@ using std::map;
 extern pthread_mutex_t lock;
 
 char *CLNTCONF_FILE = "/etc/dibbler/client.conf";
+char *CLNTPID_FILE = "/var/lib/dibbler/client.pid";
 
 TDHCPClient * ptr;
 //static const char *TOOL_NAME = "ifplugstatus";
@@ -143,7 +144,9 @@ int parse_options(std::string option, char* value)
         CLNTCONF_FILE = value;
         cout << "My new config file is: " << CLNTCONF_FILE << endl;
     } else if (option == "-P") {
-        //CLNTPID_FILE = value;
+        cout << "You passed me a PID file!" << endl;
+        CLNTPID_FILE = value;
+        cout << "My new PID file is: " << CLNTPID_FILE << endl;
     }
     return 0;
 }

--- a/Port-linux/dibbler-client.cpp
+++ b/Port-linux/dibbler-client.cpp
@@ -28,6 +28,8 @@ using std::map;
 
 extern pthread_mutex_t lock;
 
+char *CLNTCONF_FILE = "/etc/dibbler/client.conf";
+
 TDHCPClient * ptr;
 //static const char *TOOL_NAME = "ifplugstatus";
 
@@ -135,11 +137,8 @@ int help() {
 
 int main(int argc, char* argv[])
 {
-
-    CLNTCONF_FILE = "/etc/dibbler/client.conf";
-
-    char command[256];
-    int result = -1;
+//    char command[256];
+//    int result = -1;
 
     logStart("(CLIENT, Linux port)", "Client", CLNTLOG_FILE);
 
@@ -166,19 +165,17 @@ int main(int argc, char* argv[])
             result = status();
         } else if (arg == "help") {
             result = help();
-        }
-        // Parse options
-        if (arg == "-C") {
+        } else if (arg == "-C") {
             if (i + 1 < argc) {
-                //const char NEW_CONF[25] = argv[i++];
                 CLNTCONF_FILE = argv[i++];
-            }
-        }
-        if (arg == "-P") {
+            } else {
+                std::cerr << "-C requires config location." << std::endl;
+                return 1;
+            }  
+        } else if (arg == "-P") {
             if (i + 1 < argc) {
-                //const char NEW_CONF[25] = argv[i++];
                 cout << argv[i+1];
-                CLNTPID_FILE = argv[i++];
+                //CLNTPID_FILE = argv[i++];
             }
         }
     }

--- a/Port-linux/dibbler-client.cpp
+++ b/Port-linux/dibbler-client.cpp
@@ -174,11 +174,18 @@ int main(int argc, char * argv[])
                 sprintf(CLNTLOG_FILE, "%s/client.log", WORKDIR);
                 break;
             case 'A':
-                strcpy(CLNT_LLAADDR, optarg);
+                char addr[16];
+                if (inet_pton6(optarg, addr))
+                    strcpy(CLNT_LLAADDR, optarg);
+                else {
+	            cout << "Invalid IPv6 address: " << optarg << endl;
+                    help();
+                    goto exit_failure;
+                }
                 break;
             default:
                 help();
-                return EXIT_FAILURE;
+                goto exit_failure;
             }
     }
 
@@ -213,6 +220,7 @@ int main(int argc, char * argv[])
 
     logEnd();
 
+exit_failure:
     if (!default_workdir) {
         free(WORKDIR);
         free(CLNTPID_FILE);

--- a/Port-linux/dibbler-client.cpp
+++ b/Port-linux/dibbler-client.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <signal.h>
+#include <sys/stat.h>
 #include <sys/wait.h>  //CHANGED: the following two headers are added.
 #include <unistd.h>
 #include <stdlib.h>
@@ -82,7 +83,9 @@ int run() {
 	die(CLNTPID_FILE);
 	return -1;
     }
-
+    
+    chmod(CLNTPID_FILE, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    
     if (lowlevelInit()<0) {
 	cout << "Lowlevel init failed:" << error_message() << endl;
 	die(CLNTPID_FILE);

--- a/Port-linux/dibbler-client.cpp
+++ b/Port-linux/dibbler-client.cpp
@@ -34,7 +34,7 @@ TDHCPClient * ptr;
 char *WORKDIR = (char*) "/var/lib/dibbler";
 char *CLNTCONF_FILE = (char*) "/etc/dibbler/client.conf";
 char *CLNTLOG_FILE = (char*) "/var/log/dibbler/dibbler-client.log";
-char CLNT_LLAADDR[sizeof("0000:0000:0000:0000:0000:0000:0000.000.000.000.000")];
+extern char CLNT_LLAADDR[];
 
 void signal_handler(int n) {
     Log(Crit) << "Signal received. Shutting down." << LogEnd;
@@ -151,8 +151,6 @@ int main(int argc, char * argv[])
         if (len>255)
             len = 255;
         strncpy(command,argv[1],len);
-
-        memset(CLNT_LLAADDR, 0, sizeof(CLNT_LLAADDR));
 
         while ((c = getopt(argc-1, argv + 1, "W:A:")) != -1)
           switch (c)

--- a/Port-linux/dibbler-client.cpp
+++ b/Port-linux/dibbler-client.cpp
@@ -130,15 +130,14 @@ int help() {
 	 << " uninstall - Not available in Linux/Unix systems." << endl
 	 << " run       - run in the console" << endl
 	 << " help      - displays usage info." << endl
-	 << " OPTIONS: " << endl
-	 << " -C FILEPATH - Specify the config file. " << endl
-	 << " -P FILEPATH - Specify the PID file. " << endl;
+	 << " OPTIONS = -C <filepath> | -P <filepath> " << endl
+	 << " -C <filepath> - Specify the config file location. " << endl
+	 << " -P <filepath> - Specify the PID file location. " << endl;
     return 0;
 }
 
 int parse_options(std::string option, char* value)
 {
-    cout << "You've used option: " << option << " with: " << value << endl;
     if (option == "-C") {
         cout << "You passed me a config file!" << endl;
         CLNTCONF_FILE = value;
@@ -161,22 +160,18 @@ int main(int argc, char* argv[])
         std::string arg = argv[i];
         if (arg == "start") {
             if (i + 2 < argc) {
-                cout << "You've passed me an argument!" << endl;
                 parse_options(argv[i+1],argv[i+2]);
             }
             if (i + 4 < argc) {
-                cout << "You've passed me another argument!" << endl;
                 parse_options(argv[i+3],argv[i+4]);
             }
 	        result = start(CLNTPID_FILE, WORKDIR);
         } else if (arg == "run") {
             cout << "I'm running!" << endl;
             if (i + 2 < argc) {
-                cout << "You've passed me an argument!" << endl;
                 parse_options(argv[i+1],argv[i+2]);
             }
             if (i + 4 < argc) {
-                cout << "You've passed me another argument!" << endl;
                 parse_options(argv[i+3],argv[i+4]);
             }
             result = run();

--- a/Port-linux/dibbler-client.cpp
+++ b/Port-linux/dibbler-client.cpp
@@ -135,29 +135,39 @@ int help() {
     return 0;
 }
 
+int parse_options(std::string option, char* value)
+{
+    cout << "You've used option: " << option << " with: " << value << endl;
+    if (option == "-C") {
+        cout << "You passed me a config file!" << endl;
+        CLNTCONF_FILE = value;
+        cout << "My new config file is: " << CLNTCONF_FILE << endl;
+    } else if (option == "-P") {
+        //CLNTPID_FILE = value;
+    }
+    return 0;
+}
+
 int main(int argc, char* argv[])
 {
-//    char command[256];
-//    int result = -1;
+    int result = -1;
 
     logStart("(CLIENT, Linux port)", "Client", CLNTLOG_FILE);
 
-    //parse command line parameters
-//    if (argc>1) {
-//	int len = strlen(argv[1])+1;
-//	if (len>255)
-//	    len = 255;
-//	strncpy(command,argv[1],len);
-//    } else {
-//	memset(command,0,256);
-//    }
-
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
-        // Parse actions
         if (arg == "start") {
+            if (i + 2 < argc) {
+                cout << "You've passed me an argument!" << endl;
+                parse_options(argv[i+1],argv[i+2]);
+            }
 	        result = start(CLNTPID_FILE, WORKDIR);
         } else if (arg == "run") {
+            cout << "I'm running!" << endl;
+            if (i + 2 < argc) {
+                cout << "You've passed me an argument!" << endl;
+                parse_options(argv[i+1],argv[i+2]);
+            }
             result = run();
         } else if (arg == "stop") {
             result = stop(CLNTPID_FILE);
@@ -165,48 +175,14 @@ int main(int argc, char* argv[])
             result = status();
         } else if (arg == "help") {
             result = help();
-        } else if (arg == "-C") {
-            if (i + 1 < argc) {
-                CLNTCONF_FILE = argv[i++];
-            } else {
-                std::cerr << "-C requires config location." << std::endl;
-                return 1;
-            }  
-        } else if (arg == "-P") {
-            if (i + 1 < argc) {
-                cout << argv[i+1];
-                //CLNTPID_FILE = argv[i++];
-            }
+        } else if (arg == "install") {
+            cout << "Function not available in Linux/Unix systems." << endl;
+            result = 0;
+        } else if (arg == "uninstall") {
+            cout << "Function not available in Linux/Unix systems." << endl;
+            result = 0;
         }
     }
-
-//    if (!strncasecmp(command,"start",5) ) {
-//	result = start(CLNTPID_FILE, WORKDIR);
-//    } else
-//    if (!strncasecmp(command,"run",3) ) {
-//	result = run();
-//    } else
-//    if (!strncasecmp(command,"stop",4)) {
-//	result = stop(CLNTPID_FILE);
-//    } else
-//    if (!strncasecmp(command,"status",6)) {
-//	result = status();
-//    } else
-//    if (!strncasecmp(command,"help",4)) {
-//	result = help();
-//    } else
-//    if (!strncasecmp(command,"install",7)) {
-//	cout << "Function not available in Linux/Unix systems." << endl;
-//	result = 0;
-//   } else
-//    if (!strncasecmp(command,"uninstall",9)) {
-//	cout << "Function not available in Linux/Unix systems." << endl;
-//	result = 0;
-//   } else
-//    {
-//	help();
-//    }
-//    logEnd();
 
     return result? EXIT_FAILURE: EXIT_SUCCESS;
 }

--- a/Port-linux/dibbler-client.cpp
+++ b/Port-linux/dibbler-client.cpp
@@ -118,7 +118,7 @@ int run() {
 
 int help() {
     cout << "Usage:" << endl;
-    cout << " dibbler-client ACTION" << endl
+    cout << " dibbler-client ACTION OPTION" << endl
 	 << " ACTION = status|start|stop|install|uninstall|run" << endl
 	 << " status    - show status and exit" << endl
 	 << " start     - start installed service" << endl
@@ -126,55 +126,90 @@ int help() {
 	 << " install   - Not available in Linux/Unix systems." << endl
 	 << " uninstall - Not available in Linux/Unix systems." << endl
 	 << " run       - run in the console" << endl
-	 << " help      - displays usage info." << endl;
+	 << " help      - displays usage info." << endl
+	 << " OPTIONS: " << endl
+	 << " -C FILEPATH - Specify the config file. " << endl
+	 << " -P FILEPATH - Specify the PID file. " << endl;
     return 0;
 }
 
-int main(int argc, char * argv[])
+int main(int argc, char* argv[])
 {
+
+    CLNTCONF_FILE = "/etc/dibbler/client.conf";
+
     char command[256];
     int result = -1;
 
     logStart("(CLIENT, Linux port)", "Client", CLNTLOG_FILE);
 
-    // parse command line parameters
-    if (argc>1) {
-	int len = strlen(argv[1])+1;
-	if (len>255)
-	    len = 255;
-	strncpy(command,argv[1],len);
-    } else {
-	memset(command,0,256);
+    //parse command line parameters
+//    if (argc>1) {
+//	int len = strlen(argv[1])+1;
+//	if (len>255)
+//	    len = 255;
+//	strncpy(command,argv[1],len);
+//    } else {
+//	memset(command,0,256);
+//    }
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        // Parse actions
+        if (arg == "start") {
+	        result = start(CLNTPID_FILE, WORKDIR);
+        } else if (arg == "run") {
+            result = run();
+        } else if (arg == "stop") {
+            result = stop(CLNTPID_FILE);
+        } else if (arg == "status") {
+            result = status();
+        } else if (arg == "help") {
+            result = help();
+        }
+        // Parse options
+        if (arg == "-C") {
+            if (i + 1 < argc) {
+                //const char NEW_CONF[25] = argv[i++];
+                CLNTCONF_FILE = argv[i++];
+            }
+        }
+        if (arg == "-P") {
+            if (i + 1 < argc) {
+                //const char NEW_CONF[25] = argv[i++];
+                cout << argv[i+1];
+                CLNTPID_FILE = argv[i++];
+            }
+        }
     }
 
-    if (!strncasecmp(command,"start",5) ) {
-	result = start(CLNTPID_FILE, WORKDIR);
-    } else
-    if (!strncasecmp(command,"run",3) ) {
-	result = run();
-    } else
-    if (!strncasecmp(command,"stop",4)) {
-	result = stop(CLNTPID_FILE);
-    } else
-    if (!strncasecmp(command,"status",6)) {
-	result = status();
-    } else
-    if (!strncasecmp(command,"help",4)) {
-	result = help();
-    } else
-    if (!strncasecmp(command,"install",7)) {
-	cout << "Function not available in Linux/Unix systems." << endl;
-	result = 0;
-    } else
-    if (!strncasecmp(command,"uninstall",9)) {
-	cout << "Function not available in Linux/Unix systems." << endl;
-	result = 0;
-    } else
-    {
-	help();
-    }
-
-    logEnd();
+//    if (!strncasecmp(command,"start",5) ) {
+//	result = start(CLNTPID_FILE, WORKDIR);
+//    } else
+//    if (!strncasecmp(command,"run",3) ) {
+//	result = run();
+//    } else
+//    if (!strncasecmp(command,"stop",4)) {
+//	result = stop(CLNTPID_FILE);
+//    } else
+//    if (!strncasecmp(command,"status",6)) {
+//	result = status();
+//    } else
+//    if (!strncasecmp(command,"help",4)) {
+//	result = help();
+//    } else
+//    if (!strncasecmp(command,"install",7)) {
+//	cout << "Function not available in Linux/Unix systems." << endl;
+//	result = 0;
+//   } else
+//    if (!strncasecmp(command,"uninstall",9)) {
+//	cout << "Function not available in Linux/Unix systems." << endl;
+//	result = 0;
+//   } else
+//    {
+//	help();
+//    }
+//    logEnd();
 
     return result? EXIT_FAILURE: EXIT_SUCCESS;
 }

--- a/Port-linux/dibbler-relay.cpp
+++ b/Port-linux/dibbler-relay.cpp
@@ -19,6 +19,8 @@ using namespace std;
 
 TDHCPRelay * ptr = 0;
 
+char *WORKDIR = (char*) "/var/lib/dibbler";
+
 void signal_handler(int n) {
     Log(Crit) << "Signal received. Shutting down." << LogEnd;
     ptr->stop();

--- a/Port-linux/dibbler-server.cpp
+++ b/Port-linux/dibbler-server.cpp
@@ -21,6 +21,8 @@ using namespace std;
 
 TDHCPServer * ptr = 0;
 
+char *WORKDIR = (char*) "/var/lib/dibbler";
+
 void signal_handler(int n) {
     Log(Crit) << "Signal received. Shutting down." << LogEnd;
     ptr->stop();

--- a/SrvTransMgr/SrvTransMgr.cpp
+++ b/SrvTransMgr/SrvTransMgr.cpp
@@ -329,6 +329,10 @@ void TSrvTransMgr::relayMsg(SPtr<TSrvMsg> msg)
     MsgLst.first();
     while(answ=(Ptr*)MsgLst.get())
     {
+        Log(Cont) << " Peer " << answ->getClientPeer()->getPlain()
+                  << " New Peer " << msg->getClientPeer()->getPlain() << LogEnd;
+        if (*(answ->getClientPeer()) != *(msg->getClientPeer()))
+            continue;
         if (answ->getTransID()==msg->getTransID() && msg->getType() != RELEASE_MSG ) {
             Log(Cont) << " Old reply with transID=" << hex << msg->getTransID()
                       << dec << " found. Sending old reply." << LogEnd;

--- a/SrvTransMgr/SrvTransMgr.cpp
+++ b/SrvTransMgr/SrvTransMgr.cpp
@@ -329,8 +329,6 @@ void TSrvTransMgr::relayMsg(SPtr<TSrvMsg> msg)
     MsgLst.first();
     while(answ=(Ptr*)MsgLst.get())
     {
-        Log(Cont) << " Peer " << answ->getClientPeer()->getPlain()
-                  << " New Peer " << msg->getClientPeer()->getPlain() << LogEnd;
         if (*(answ->getClientPeer()) != *(msg->getClientPeer()))
             continue;
         if (answ->getTransID()==msg->getTransID() && msg->getType() != RELEASE_MSG ) {


### PR DESCRIPTION
Hi Tomasz, we are trying to use dibbler client to implement PD for openstack neutron. A few changes in the linux port that we have to make in order to meet our needs:
  -- to be able to run multiple instances of the dibbler client in a single node. To do that, we localized most of the files used by the dibbler client, duid, pid, log, .xml etc.
  -- to be able to run multiple instances of the dibbler client on a single interface. To do that, we bound the socket of each client to a unique LLA address. Each client is responsible for a single PD request. We thought of dynamically changing the client's configuration in order to request/release multiple PD leases dynamically. However, we felt that would require more work/change, and time is not on our side. Further change may be needed so that the unicast socket is also bound to a unique source LLA. 
  -- a little change on the server side so that questions and answers are matched based on not just transaction id, but also the sender's (peer's) address of the request. In our test, we also used Dibbler server, and the change was needed so that the server wouldn't get confused when receiving multiple requests from multiple clients at the same time.

We need this change ASAP in order to meet our neutron PD development deadline for Kilo release (https://wiki.openstack.org/wiki/Kilo_Release_Schedule). Therefore, we are hoping that this change can be reviewed and revised if needed and pushed upstream ASAP. 

Your response will be highly appreciated!

Thanks,
Robert, John