### PR TITLE
Compatibility patch for musl

### DIFF
--- a/Misc/Portable.h.in
+++ b/Misc/Portable.h.in
@@ -29,6 +29,10 @@
 #include <arpa/inet.h>
 #endif
 
+#if defined(LINUX)
+# include <sys/select.h>
+#endif
+
 #include <stdint.h>
 #include <unistd.h>
 

--- a/Port-linux/ethtool-local.h
+++ b/Port-linux/ethtool-local.h
@@ -22,9 +22,9 @@
  */
 
 typedef unsigned long long u64;
-typedef __uint32_t u32;        
-typedef __uint16_t u16;        
-typedef __uint8_t u8;          
+typedef uint32_t u32;        
+typedef uint16_t u16;        
+typedef uint8_t u8;          
 
 #include "ethtool-kernel.h"
 

--- a/Port-linux/lowlevel-linux-link-state.c
+++ b/Port-linux/lowlevel-linux-link-state.c
@@ -18,7 +18,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <bits/sigthread.h>
+#if defined(__GLIBC__)
+# include <bits/sigthread.h>
+#endif
 #include "Portable.h"
 #include "interface.h"
 

--- a/Port-linux/utils.h
+++ b/Port-linux/utils.h
@@ -1,9 +1,14 @@
 #ifndef __UTILS_H__
 #define __UTILS_H__ 1
 
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+
 #include <asm/types.h>
 //#include <resolv.h>
 #include <linux/types.h>
+#include <sys/types.h>
 
 #include "libnetlink.h"
 #include "ll_map.h"


### PR DESCRIPTION
Minor header/include/typedef changes to fix compatibility with musl libc.
Doesn't break compatibility with glibc, as far as I can tell.