### PR TITLE
PD renew: correctly update valid lifetime

### DIFF
--- a/AddrMgr/AddrMgr.cpp
+++ b/AddrMgr/AddrMgr.cpp
@@ -487,7 +487,7 @@ bool TAddrMgr::updatePrefix(SPtr<TAddrClient> client, SPtr<TDUID> duid , SPtr<TI
 
     ptrPrefix->setTimestamp();
     ptrPrefix->setPref(pref);
-    ptrPrefix->setValid(pref);
+    ptrPrefix->setValid(valid);
 
     return true;
 }


### PR DESCRIPTION
In some scenarios this would cause the client (after renewing the prefix lease once) to always time out the prefix instead of renewing it (in case T1 and T2 timers are irrelevant, e.g. set to 'pref') as the valid lifetime was set to pref lifetime.