### PR TITLE
Fix portabilty for "=" operator of test(1)

### DIFF
--- a/configure
+++ b/configure
@@ -17070,7 +17070,7 @@ $as_echo_n "checking which port is appropriate for this system... " >&6; }
       ARCH="BSD"
       PORT_SUBDIR="Port-bsd"
       PORT_CFLAGS=""
-      if test "$NEED_RFC_3542" == "yes"; then
+      if test "$NEED_RFC_3542" = "yes"; then
         PORT_CFLAGS="-D__APPLE_USE_RFC_3542"
       fi
       PORT_LDFLAGS=

--- a/configure.ac
+++ b/configure.ac
@@ -230,7 +230,7 @@ dnl ---------------------------------------------
       ARCH="BSD"
       PORT_SUBDIR="Port-bsd"
       PORT_CFLAGS=""
-      if test "$NEED_RFC_3542" == "yes"; then
+      if test "$NEED_RFC_3542" = "yes"; then
         PORT_CFLAGS="-D__APPLE_USE_RFC_3542"
       fi
       PORT_LDFLAGS=


### PR DESCRIPTION
"==" operator for test(1) is a bash-izm, and it should not be used in portable configure script.