### PR TITLE
Fix to include <stdlib.h> for EXIT_SUCCESS and EXIT_FAILURE

### DIFF
--- a/Port-bsd/dibbler-server.cpp
+++ b/Port-bsd/dibbler-server.cpp
@@ -12,6 +12,7 @@
 
 #include <signal.h>
 #include <string.h>
+#include <stdlib.h>
 #include "DHCPServer.h"
 #include "Portable.h"
 #include "Logger.h"


### PR DESCRIPTION
At least, it is required on NetBSD-7.0.