### PR TITLE
ClntIfaceMgr: fix PD prefixes offset calculation, causing stack overflow

### DIFF
--- a/ClntIfaceMgr/ClntIfaceMgr.cpp
+++ b/ClntIfaceMgr/ClntIfaceMgr.cpp
@@ -593,7 +593,7 @@ bool TClntIfaceMgr::modifyPrefix(int iface, SPtr<TIPv6Addr> prefix, int prefixLe
             subprefixLen = prefixLen;
         } else if (ifaceLst.size()<256) {
             subprefixLen = prefixLen + bit_shift;
-            int offset = prefixLen/bit_shift;
+            int offset = (prefixLen+bit_shift) / 8;
             if (prefixLen%8 == 0) {
                 // that's easy, just put ID in the next octet
                 buf[offset] = (*i)->getID();


### PR DESCRIPTION
Say, when ifaceLst.size() == 3 , then bit_shift = 2 and previous
code would set offset = 56/2 = 28, out of buf bounds.

`offset` needs to be byte boundary of (prefix + bit_shift) bits.
