### PR TITLE
Fix bug in BindReuse condition check. 

### DIFF
--- a/ClntTransMgr/ClntTransMgr.cpp
+++ b/ClntTransMgr/ClntTransMgr.cpp
@@ -382,7 +382,8 @@ void TClntTransMgr::checkDB()
 bool TClntTransMgr::openLoopbackSocket() {
     SPtr<TIfaceIface> ptrIface;
 
-    if (!this->BindReuse)
+    // if BindReuse is set, return true from here and dont create new loopback socket to allow multiple instances 
+    if (this->BindReuse)
         return true;
 
 #ifndef WIN32


### PR DESCRIPTION
When BindReuse is set we allow multiple instances to run.
 So we should return from TClntTransMgr::openLoopbackSocket() when BindReuse is set to true (instead we are erroneously returning when BindReuse is false) and should not proceed further to create a new open loopback socket.

Test:
1) Run a process that binds to "::"  (e.g. ti_dhcp6c)
2) Run dibbler-client with BINDREUSE option set. 
expected: dibbler-client should run
observed: dibbler-client is exiting with error in socket bind.
Fixed: After the fix, I am able to run dibbler-client
