### PR TITLE
Fixed vulnerabilities with time checking.

### DIFF
--- a/AddrMgr/AddrAddr.cpp
+++ b/AddrMgr/AddrAddr.cpp
@@ -33,6 +33,12 @@ TAddrAddr::TAddrAddr(SPtr<TIPv6Addr> addr, long pref, long valid) {
     this->Valid = valid;
     this->Addr=addr;
     this->Timestamp = (unsigned long)time(NULL);
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts) == 0) {
+	    //The time we are taking is with reference to boot time,
+	    //which is not changed wvwn when the NTP updates the latest time.
+	    this->Timestamp = (unsigned long)ts.tv_sec;
+    }
     this->Tentative = ADDRSTATUS_UNKNOWN;
     this->Prefix = 128;
 
@@ -59,6 +65,14 @@ TAddrAddr::TAddrAddr(SPtr<TIPv6Addr> addr, long pref, long valid, int prefix) {
     this->Valid = valid;
     this->Addr=addr;
     this->Timestamp = (unsigned long)time(NULL);
+
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts) == 0) {
+	    //The time we are taking is with reference to boot time,
+	    //which is not changed wvwn when the NTP updates the latest time.
+	    this->Timestamp = (unsigned long)ts.tv_sec;
+    }
+
     this->Tentative = ADDRSTATUS_UNKNOWN;
     this->Prefix = prefix;
 
@@ -96,7 +110,11 @@ SPtr<TIPv6Addr> TAddrAddr::get() {
 unsigned long TAddrAddr::getPrefTimeout()
 {
     unsigned long ts = Timestamp + Prefered;
+    struct timespec ts_local;
     unsigned long x  = (unsigned long)time(NULL);
+    if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts_local) == 0) {
+	    x  = (unsigned long)ts_local.tv_sec;
+    }
     if (ts<Timestamp) { // (Timestamp + T1 overflowed (unsigned long) maximum value
         return DHCPV6_INFINITY;
     }
@@ -117,6 +135,11 @@ unsigned long TAddrAddr::getValidTimeout()
 {
     unsigned long ts = Timestamp + Valid;
     unsigned long x  = (unsigned long)time(NULL);
+
+    struct timespec ts_local;
+    if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts_local) == 0) {
+	    x = (unsigned long)ts_local.tv_sec;
+    }
     if (ts<Timestamp) { // (Timestamp + T1 overflowed (unsigned long) maximum value
 	return DHCPV6_INFINITY;
     }
@@ -158,6 +181,10 @@ void TAddrAddr::setValid(unsigned long valid)
 void TAddrAddr::setTimestamp()
 {
     this->Timestamp = (unsigned long)time(NULL);
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts) == 0) {
+	    this->Timestamp = (unsigned long)ts.tv_sec;
+    }
 }
 
 enum EAddrStatus TAddrAddr::getTentative()


### PR DESCRIPTION
When a system time is changed, the saved time which is calculated using system call time(),
is compared with latest time, All the addresses are timing out and we are reacquiring the address.

Changed to use CLOCK_MONOTONIC_RAW, which is equivalent to hardware ticks.
This will be constant even if the system time changed.

Signed-off-by: Balaji Punnuru <balaji_punnuru@cable.comcast.com>