### PR TITLE
Fix to trigger client-notify script whenever the expiry event occurs for addresses/prefixes assigned from remote DHCPv6 server.

### DIFF
--- a/ClntIfaceMgr/ClntIfaceMgr.cpp
+++ b/ClntIfaceMgr/ClntIfaceMgr.cpp
@@ -492,6 +492,13 @@ bool TClntIfaceMgr::modifyPrefix(int iface, SPtr<TIPv6Addr> prefix, int prefixLe
         return false;
     }
 
+    if (mode == PREFIX_MODIFY_DEL) {
+        Log(Info) << "PD: Client notify script invoked as prefix " << prefix->getPlain()
+                  << "/" << (int)prefixLen << " going to be deleted." << LogEnd;
+        ClntTransMgr().notifyExpiredInfo(*params, prefix, IATYPE_PD, (int)prefixLen);
+        notifyScript(ClntCfgMgr().getScript(), "expire", *params);
+     }
+
     // get a list of interfaces that we will assign prefixes to
     TIfaceIfaceLst ifaceLst;
     vector<string> ifaceNames = ClntCfgMgr().getDownlinkPrefixIfaces();

--- a/ClntMessages/ClntMsgRebind.cpp
+++ b/ClntMessages/ClntMsgRebind.cpp
@@ -21,6 +21,7 @@
 #include "OptAddr.h"
 #include "AddrIA.h"
 #include "Logger.h"
+#include "IfaceMgr.h"
 
 using namespace std;
 
@@ -276,6 +277,7 @@ void TClntMsgRebind::releaseIA(int IAID)
         return;
     }
 
+    TNotifyScriptParams params;
     SPtr<TAddrAddr> ptrAddr;
     ptrAddrIA->firstAddr();
     while(ptrAddr=ptrAddrIA->getAddr())
@@ -286,6 +288,9 @@ void TClntMsgRebind::releaseIA(int IAID)
 	    Log(Error) << "Unable to find interface with ifindex " << ptrAddrIA->getIfindex() << LogEnd;
 	    continue;
 	}
+        // Client Notify script invoked
+        ClntTransMgr().notifyExpiredInfo(params, ptrAddr->get(), IATYPE_IA);
+        ClntIfaceMgr().notifyScript(ClntCfgMgr().getScript(), "expire", params);
 	ptrIface->delAddr(ptrAddr->get(), ptrIface->getPrefixLength());
         //and from db
         ptrAddrIA->delAddr(ptrAddr->get());

--- a/ClntTransMgr/ClntTransMgr.cpp
+++ b/ClntTransMgr/ClntTransMgr.cpp
@@ -246,6 +246,7 @@ void TClntTransMgr::removeExpired() {
 	    Log(Info) << "Expired address " << ptrAddr->get()->getPlain()
 		      << " from IA " << ptrIA->getIAID()
 		      << " has been removed from addrDB." << LogEnd;
+            notifyExpiredInfo(params, ptrAddr->get(), IATYPE_IA);
         }
 
 	// if there are no more addresses in this IA, declare it freed
@@ -287,6 +288,7 @@ void TClntTransMgr::removeExpired() {
 	    Log(Info) << "Expired temporary address " << ptrAddr->get()->getPlain()
 		      << " from IA " << ptrIA->getIAID()
 		      << " has been removed from addrDB." << LogEnd;
+            notifyExpiredInfo(params, ptrAddr->get(), IATYPE_TA);
         }
 
 	// if there are no more addresses in this IA, declare it freed
@@ -332,6 +334,7 @@ void TClntTransMgr::removeExpired() {
 	    Log(Info) << "Expired prefix " << ptrPrefix->get()->getPlain() << "/" << ptrPrefix->getLength()
 		      << " from IA_PD " << ptrPD->getIAID()
 		      << " has been removed from addrDB." << LogEnd;
+            notifyExpiredInfo(params, ptrPrefix->get(), IATYPE_PD, ptrPrefix->getLength());
         }
 
 	// if there are no more addresses in this IA, declare it freed
@@ -348,7 +351,8 @@ void TClntTransMgr::removeExpired() {
 	    }
 	}
     }
-
+    // Client Notify script invoked
+    ClntIfaceMgr().notifyScript(ClntCfgMgr().getScript(), "expire", params);
 }
 
 /** 
@@ -1424,6 +1428,30 @@ bool TClntTransMgr::sanitizeAddrDB() {
                                               currentIndexToName);
 }
 
+/* @brief notifyExpiredInfo() invoked when expiry occurs for addresses/prefixes.
+   This method can be modified as per the client requirements.
+*/
+void TClntTransMgr::notifyExpiredInfo(TNotifyScriptParams& params, SPtr<TIPv6Addr> exp, TIAType type, int prefixLength)
+{
+
+    switch (type) {
+        case IATYPE_IA:
+        {
+            params.addAddr(exp, 0, 0, "");
+            break;
+        }
+        case IATYPE_TA:
+        {
+            params.addAddr(exp, 0, 0, "");
+            break;
+        }
+        case IATYPE_PD:
+        {
+            params.addPrefix(exp, prefixLength, 0, 0);
+            break;
+        }
+    }
+}
 
 #ifdef MOD_REMOTE_AUTOCONF
 SPtr<TClntTransMgr::TNeighborInfo> TClntTransMgr::neighborInfoGet(SPtr<TIPv6Addr> addr) {

--- a/ClntTransMgr/ClntTransMgr.h
+++ b/ClntTransMgr/ClntTransMgr.h
@@ -59,6 +59,7 @@ class TClntTransMgr
     void printAdvertiseLst();
 
     bool sanitizeAddrDB();
+    void notifyExpiredInfo(TNotifyScriptParams& params, SPtr<TIPv6Addr> exp, TIAType type, int prefixLength = 0);
 
 #ifdef MOD_REMOTE_AUTOCONF
     struct TNeighborInfo {


### PR DESCRIPTION
Fix to trigger client-notify script whenever the expiry event occurs for addresses/prefixes assigned.