### PR TITLE
Fix minor memory leaks

### DIFF
--- a/ClntCfgMgr/ClntParser.cpp
+++ b/ClntCfgMgr/ClntParser.cpp
@@ -2062,6 +2062,7 @@ case 111:
 #line 553 "ClntParser.y"
 {
     logger::setLogMode(yyvsp[0].strval);
+    delete [] yyvsp[0].strval;
 ;
     break;}
 case 112:
@@ -2155,6 +2156,7 @@ case 121:
 #line 640 "ClntParser.y"
 {
     CfgMgr->setScript(yyvsp[0].strval);
+    delete [] yyvsp[0].strval;
 ;
     break;}
 case 122:
@@ -2609,11 +2611,11 @@ case 190:
     break;}
 case 191:
 #line 1070 "ClntParser.y"
-{ PresentStringLst.append(SPtr<string> (new string(yyvsp[0].strval))); ;
+{ PresentStringLst.append(SPtr<string> (new string(yyvsp[0].strval))); delete [] yyvsp[0].strval;;
     break;}
 case 192:
 #line 1071 "ClntParser.y"
-{ PresentStringLst.append(SPtr<string> (new string(yyvsp[0].strval))); ;
+{ PresentStringLst.append(SPtr<string> (new string(yyvsp[0].strval))); delete [] yyvsp[0].strval;;
     break;}
 case 193:
 #line 1074 "ClntParser.y"

--- a/ClntCfgMgr/ClntParser.y
+++ b/ClntCfgMgr/ClntParser.y
@@ -552,6 +552,7 @@ LogLevelOption
 LogModeOption
 : LOGMODE_ STRING_ {
     logger::setLogMode($2);
+    delete [] $2;
 }
 
 LogNameOption
@@ -639,6 +640,7 @@ ScriptName
 : SCRIPT_ STRING_
 {
     CfgMgr->setScript($2);
+    delete [] $2;
 }
 
 AuthAcceptMethods
@@ -1067,8 +1069,8 @@ ADDRESSList
 ;
 
 StringList
-: STRING_ { PresentStringLst.append(SPtr<string> (new string($1))); }
-| StringList ',' STRING_ { PresentStringLst.append(SPtr<string> (new string($3))); }
+: STRING_ { PresentStringLst.append(SPtr<string> (new string($1))); delete [] $1;}
+| StringList ',' STRING_ { PresentStringLst.append(SPtr<string> (new string($3))); delete [] $3; }
 
 Number
 :  HEXNUMBER_ {$$=$1;}

--- a/Port-linux/lowlevel-linux-link-state.c
+++ b/Port-linux/lowlevel-linux-link-state.c
@@ -114,7 +114,7 @@ void * checkLinkState(void * ptr){
 	/* printf("."); */
 	sleep(1);
     }
-    /* if_list_release(head); */
+    if_list_release(head);
     /* printf("Finishing link-state change\n"); */
 
     /* pthread_exit(NULL); */


### PR DESCRIPTION
=================================================================
==157330==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 576 byte(s) in 1 object(s) allocated from:
    #0 0x7f7ecd050628 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x107628)
    #1 0x561569188e82 in if_list_get /dibbler/Port-linux/lowlevel-linux.c:222

Direct leak of 38 byte(s) in 1 object(s) allocated from:
    #0 0x7f7ecd05236f in operator new[](unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x10936f)
    #1 0x56156914a104 in yyFlexLexer::yylex() /dibbler/ClntCfgMgr/ClntLexer.cpp:2318

Direct leak of 22 byte(s) in 3 object(s) allocated from:
    #0 0x7f7ecd05236f in operator new[](unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x10936f)
    #1 0x56156914a203 in yyFlexLexer::yylex() /dibbler/ClntCfgMgr/ClntLexer.cpp:2341

Indirect leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f7ecd050628 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x107628)
    #1 0x561569188af8 in ipaddr_local_get /dibbler/Port-linux/lowlevel-linux.c:289