### PR TITLE
Fix calling parameters for TOptIAPrefix to avoid wrong prefix length

### DIFF
--- a/ClntOptions/ClntOptIA_PD.cpp
+++ b/ClntOptions/ClntOptIA_PD.cpp
@@ -62,9 +62,10 @@ TClntOptIA_PD::TClntOptIA_PD(SPtr<TClntCfgPD> cfgPD, TMsg* parent)
     SPtr<TClntCfgPrefix> cfgPrefix;
     while (cfgPrefix = cfgPD->getPrefix() ) {
         SubOptions.append(new TOptIAPrefix(cfgPrefix->get(),
+                                               cfgPrefix->getLength(),
                                                cfgPrefix->getPref(),
                                                cfgPrefix->getValid(),
-                                               cfgPrefix->getLength(), 0));
+                                               0));
     }
     clearContext();
 }


### PR DESCRIPTION
prefix length and validity were swapped causing wrong prefix length to
be requested (often 255) during prefix delegation in SOLICIT messages.

Signed-off-by: Matthieu Patou <mat@matws.net>