### PR TITLE
Server to validate all IA_NA in the received RENEW/REBIND messages

### DIFF
--- a/SrvOptions/SrvOptIA_NA.h
+++ b/SrvOptions/SrvOptIA_NA.h
@@ -40,6 +40,7 @@ class TSrvOptIA_NA : public TOptIA_NA
     void release(SPtr<TSrvOptIA_NA> queryOpt, unsigned long &addrCount);
     void decline(SPtr<TSrvOptIA_NA> queryOpt, unsigned long &addrCount);
     bool doDuties();
+    bool checkAddrOnLink(SPtr<TSrvOptIA_NA> queryOpt);
  private:
     bool assignCachedAddr(bool quiet);
     bool assignRequestedAddr(SPtr<TSrvMsg> queryMsg, SPtr<TSrvOptIA_NA> queryOpt, bool quiet);
@@ -52,6 +53,7 @@ class TSrvOptIA_NA : public TOptIA_NA
     SPtr<TIPv6Addr>   ClntAddr;
     SPtr<TDUID>       ClntDuid;
     int                   Iface;
+    int                   MsgType;
 
     SPtr<TIPv6Addr> getFreeAddr(SPtr<TIPv6Addr> hint);
     SPtr<TIPv6Addr> getExceptionAddr();


### PR DESCRIPTION
_RFC8415 :_ If the server finds that any of the addresses in the IA are not appropriate for the link to which the client is attached, the server returns the address to the client with lifetimes of 0.