### PR TITLE
fix #56 on linux file radvd.conf grow indefinitly

### DIFF
--- a/Port-linux/lowlevel-options-linux.c
+++ b/Port-linux/lowlevel-options-linux.c
@@ -469,7 +469,7 @@ void add_radvd_conf(const char* ifname, const char* prefixPlain, int prefixLengt
     }
     fseek(f, 0, SEEK_END);
 
-    fprintf(f, "\n### %s start ###\n", ifname);
+    fprintf(f, "### %s start ###\n", ifname);
     fprintf(f, "interface %s \n", ifname);
     fprintf(f, "{ \n");
     fprintf(f, "     AdvSendAdvert on; \n");
@@ -482,7 +482,6 @@ void add_radvd_conf(const char* ifname, const char* prefixPlain, int prefixLengt
     fprintf(f, "     };\n");
     fprintf(f, "};\n");
     fprintf(f, "### %s end ###\n", ifname);
-    fprintf(f, "\n");
 
     fclose(f);
 }


### PR DESCRIPTION
Hello,

This very simple patch only remove 2 `\n` surrounding the config block generated in `add_radvd_conf()` to match the same config block that will be deleted by `delete_radvd_conf()`.

I'm aware that the project is no more maintained, anyway, I hope this can help